### PR TITLE
Use spawn for dive execution with input validation

### DIFF
--- a/backend/test/dive.test.js
+++ b/backend/test/dive.test.js
@@ -1,0 +1,8 @@
+const diveUtils = require('../utils/dive');
+
+describe('Dive Utils input validation', () => {
+  test('rejects malicious image names', async () => {
+    await expect(diveUtils.executeDiveSync('alpine;rm -rf /'))
+      .rejects.toThrow('Invalid image name');
+  });
+});


### PR DESCRIPTION
## Summary
- replace execAsync dive calls with spawn to avoid shell invocation
- validate image names against existing regex before running dive
- add unit test confirming malicious image names are rejected

## Testing
- `npm run test:backend`
- `npm test` *(fails: No tests found in frontend)*
- `npm run lint:backend` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9e22de7883229c27ae085a361e90