### PR TITLE
feat: add interactive dive terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A modern, containerized web interface for analyzing Docker images using the [div
 - 🔬 **Layer-by-Layer**: Detailed breakdown of each Docker layer with file counts and sizes
 - 📈 **Efficiency Insights**: Actionable recommendations for image optimization
 - 🎯 **Interactive Commands**: Expandable/collapsible Docker layer commands with syntax highlighting
+- 🖥️ **Dive Terminal**: Interactive PTY session streaming `dive <image>` output
 - ☁️ **Kubernetes Ready**: Complete Helm chart for Kubernetes deployment with AWS EKS optimizations
 - 🔧 **Enhanced UX**: Intelligent error handling with graceful fallbacks
 - 🚀 **CI/CD Automation**: Complete GitHub Actions workflows with automated deployment
@@ -306,6 +307,7 @@ Your CI/CD system is optimized for the GitHub free tier while providing enterpri
 
 ### Real-time Updates
 - `WebSocket /ws/inspect` - Real-time analysis progress updates
+- `Socket.IO /ws/terminal?image=<tag>` - Interactive dive terminal session
 
 ### Example API Usage
 
@@ -325,6 +327,16 @@ curl http://localhost:3000/api/health
 # Clean up analysis artifacts
 curl -X DELETE http://localhost:3000/api/inspect/nginx:alpine
 ```
+
+## Terminal Usage
+
+The `/ws/terminal` Socket.IO namespace streams a live `dive <image>` session.
+
+### Keybinds
+
+- Type commands directly to interact with dive
+- `q` or `Ctrl+C` — exit the session
+- `Resize` button or window resize — fit terminal dimensions
 
 ## Development
 
@@ -604,4 +616,4 @@ Have an idea? [Open an issue](https://github.com/aurablacklight/docker-dive-web-
 - **Setup**: `./setup-docker-local.sh` (one-time configuration)
 - **Performance**: 13x faster builds with BuildKit optimization
 # CI/CD Test
-This line was added to test the CI/CD pipeline.
+This line verifies the CI/CD pipeline is operational.

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,27 +13,29 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "helmet": "^7.1.0",
-    "express-rate-limit": "^7.1.0",
-    "socket.io": "^4.7.4",
     "axios": "^1.6.0",
-    "joi": "^17.11.0",
-    "winston": "^3.11.0",
-    "dotenv": "^16.3.0",
     "compression": "^1.7.4",
-    "morgan": "^1.10.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.0",
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.1.0",
+    "express-validator": "^7.0.0",
     "fs-extra": "^11.1.0",
+    "helmet": "^7.1.0",
+    "joi": "^17.11.0",
+    "morgan": "^1.10.0",
+    "node-pty": "^1.0.0",
+    "socket.io": "^4.7.4",
     "uuid": "^9.0.0",
-    "express-validator": "^7.0.0"
+    "winston": "^3.11.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.0",
-    "jest": "^29.7.0",
-    "supertest": "^6.3.0",
     "eslint": "^8.54.0",
-    "prettier": "^3.1.0"
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.0",
+    "prettier": "^3.1.0",
+    "socket.io-client": "^4.8.1",
+    "supertest": "^6.3.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/backend/test/terminal.test.js
+++ b/backend/test/terminal.test.js
@@ -1,0 +1,48 @@
+const { io } = require('socket.io-client');
+
+jest.setTimeout(30000);
+
+let server;
+
+beforeAll((done) => {
+  const serverModule = require('../server');
+  server = serverModule.server;
+  server.listen(3000, done);
+});
+
+afterAll((done) => {
+  if (server && server.listening) {
+    server.close(done);
+  } else {
+    done();
+  }
+});
+
+test('PTY bridge echoes output and exits cleanly', (done) => {
+  const socket = io('http://localhost:3000/ws/terminal', {
+    query: { image: 'alpine:latest' },
+    transports: ['websocket']
+  });
+
+  let received = false;
+
+  socket.on('data', (data) => {
+    if (!received && data) {
+      received = true;
+      socket.emit('data', 'q');
+    }
+  });
+
+  socket.on('exit', (code) => {
+    try {
+      expect(received).toBe(true);
+      expect(typeof code).toBe('number');
+      socket.disconnect();
+      done();
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  socket.on('error', (err) => done(err instanceof Error ? err : new Error(err)));
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,9 @@
     "lucide-react": "^0.400.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "socket.io-client": "^4.7.4"
+    "socket.io-client": "^4.7.4",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/frontend/src/components/TerminalView.js
+++ b/frontend/src/components/TerminalView.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useRef } from 'react';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import { io } from 'socket.io-client';
+import 'xterm/css/xterm.css';
+
+const TerminalView = ({ image, onExit }) => {
+  const containerRef = useRef(null);
+  const termRef = useRef(null);
+  const socketRef = useRef(null);
+  const fitRef = useRef(null);
+
+  useEffect(() => {
+    const term = new Terminal();
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(containerRef.current);
+    fitAddon.fit();
+    term.focus();
+
+    const socket = io(
+      process.env.NODE_ENV === 'production'
+        ? '/ws/terminal'
+        : 'http://localhost:3000/ws/terminal',
+      { query: { image } }
+    );
+
+    term.onData(data => socket.emit('data', data));
+    socket.on('data', d => term.write(d));
+    socket.on('exit', code => {
+      term.write(`\r\nProcess exited with code ${code}\r\n`);
+      if (onExit) onExit(code);
+    });
+
+    const handleResize = () => {
+      fitAddon.fit();
+      socket.emit('resize', { cols: term.cols, rows: term.rows });
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    termRef.current = term;
+    socketRef.current = socket;
+    fitRef.current = fitAddon;
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      socket.disconnect();
+      term.dispose();
+    };
+  }, [image, onExit]);
+
+  const handleExit = () => {
+    socketRef.current?.emit('data', 'q');
+  };
+
+  const handleManualResize = () => {
+    if (fitRef.current && termRef.current && socketRef.current) {
+      fitRef.current.fit();
+      socketRef.current.emit('resize', { cols: termRef.current.cols, rows: termRef.current.rows });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div ref={containerRef} className="terminal" />
+      <div className="flex space-x-2">
+        <button onClick={handleExit} className="glass px-3 py-1">Exit</button>
+        <button onClick={handleManualResize} className="glass px-3 py-1">Resize</button>
+      </div>
+    </div>
+  );
+};
+
+export default TerminalView;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "helmet": "^7.1.0",
         "joi": "^17.11.0",
         "morgan": "^1.10.0",
+        "node-pty": "^1.0.0",
         "socket.io": "^4.7.4",
         "uuid": "^9.0.0",
         "winston": "^3.11.0"
@@ -46,6 +47,7 @@
         "jest": "^29.7.0",
         "nodemon": "^3.0.0",
         "prettier": "^3.1.0",
+        "socket.io-client": "^4.8.1",
         "supertest": "^6.3.0"
       },
       "engines": {
@@ -69,13 +71,13 @@
       "name": "dive-inspector-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@openreplay/tracker": "^16.4.8",
-        "@openreplay/tracker-assist": "^11.0.8",
         "axios": "^1.6.0",
         "lucide-react": "^0.400.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "socket.io-client": "^4.7.4"
+        "socket.io-client": "^4.7.4",
+        "xterm": "^5.3.0",
+        "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.0",
@@ -2848,42 +2850,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@openreplay/network-proxy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@openreplay/network-proxy/-/network-proxy-1.2.0.tgz",
-      "integrity": "sha512-vIOzBWVKn+7/Dk4qFmRxR1fdOEnLt1hXkEYtc3m7eIA2nVwz+BSGW4Hbs/ygFLnNS0HkcBwuRgmXAwRMK5HCrQ==",
-      "license": "MIT"
-    },
-    "node_modules/@openreplay/tracker": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@openreplay/tracker/-/tracker-16.4.8.tgz",
-      "integrity": "sha512-IB/yIzquRQAYGch55tkwXm0dKN2eKAzLNbxD6I21bKOlcWy+PfOMqb7p4opKR+vE/BReGUG3q7Cl1S6BghDUWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@openreplay/network-proxy": "^1.2.0",
-        "error-stack-parser": "^2.1.4",
-        "error-stack-parser-es": "^0.1.5",
-        "fflate": "^0.8.2",
-        "web-vitals": "^4.2.4"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
-    "node_modules/@openreplay/tracker-assist": {
-      "version": "11.0.8",
-      "resolved": "https://registry.npmjs.org/@openreplay/tracker-assist/-/tracker-assist-11.0.8.tgz",
-      "integrity": "sha512-Sj1q3MChiiWShGSKDcb10rCdlAVi0VqA+NUnEmdfdSYUlc/lQZWnU4EbpfwSiWd32Ns9pKIohlZPJoulcJ4sdg==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.10",
-        "fflate": "^0.8.2",
-        "socket.io-client": "^4.8.1"
-      },
-      "peerDependencies": {
-        "@openreplay/tracker": ">=14.0.14"
-      }
-    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -5566,7 +5532,9 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6203,24 +6171,6 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/error-stack-parser": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
-      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
-      }
-    },
-    "node_modules/error-stack-parser-es": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-0.1.5.tgz",
-      "integrity": "sha512-xHku1X40RO+fO8yJ8Wh2f2rZWVjqyhb1zgq1yZ8aZRQkv6OOKhKWRUaht3eSCUbAOBaKIgM+ykwFLE+QUxgGeg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-abstract": {
@@ -6969,12 +6919,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "license": "MIT"
-    },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -10552,6 +10496,12 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -10621,6 +10571,16 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.17.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -13076,12 +13036,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stackframe": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
-      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-      "license": "MIT"
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -14163,12 +14117,6 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/webpack": {
       "version": "5.101.3",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
@@ -14675,6 +14623,23 @@
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
+      "license": "MIT"
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
+      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
+      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
## Summary
- stream dive output through `/ws/terminal` using node-pty and Socket.IO
- add `TerminalView` with xterm.js to drive interactive sessions
- document terminal usage and add smoke test for PTY bridge
- clarify CI/CD test note in README

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test:backend`
- `npm run test:frontend` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9b6f342c8322b2cf28694752fb6d