### PR TITLE
feat: cleanup orphan pty processes

### DIFF
--- a/backend/test/pty-cleanup.test.js
+++ b/backend/test/pty-cleanup.test.js
@@ -1,0 +1,29 @@
+const { killAllPTYs, activePTYs } = require("../server");
+const pty = require("node-pty");
+
+jest.setTimeout(10000);
+
+test("killAllPTYs terminates tracked PTYs", (done) => {
+  const shell = pty.spawn("bash", ["-c", "sleep 1000"], {
+    name: "xterm-color",
+    cols: 80,
+    rows: 30,
+    env: process.env,
+  });
+
+  activePTYs.add(shell);
+  const pid = shell.pid;
+
+  killAllPTYs();
+
+  setTimeout(() => {
+    let alive = true;
+    try {
+      process.kill(pid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+    done();
+  }, 200);
+});


### PR DESCRIPTION
## Summary
- track all spawned PTYs in the backend
- kill lingering PTYs on disconnect, SIGINT and SIGTERM
- add regression test for PTY cleanup helper

## Testing
- `npm run test:backend -- -i`
- `npm run lint:backend` *(fails: ESLint couldn't find a configuration file)*
- `npm run format:backend` *(fails: SyntaxError in routes/inspect_backup.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa1532d288322a85e851547e8dfbd