### PR TITLE
refactor: streamline dive API

### DIFF
--- a/backend/routes/inspect.js
+++ b/backend/routes/inspect.js
@@ -316,12 +316,12 @@ router.post('/:imageName*',
         message: 'Starting dive analysis...'
       });
 
-      const analysis = await diveUtils.executeDive(decodedImageName, (diveUpdate) => {
-        progressCallback({
-          status: 'analyzing',
-          progress: Math.min(60 + (diveUpdate.progress || 0) * 0.35, 95), // 60-95%
-          message: diveUpdate.message || 'Analyzing image layers...'
-        });
+      const analysis = await diveUtils.executeDive(decodedImageName);
+
+      progressCallback({
+        status: 'analyzing',
+        progress: 95,
+        message: 'Processing analysis results...'
       });
 
       // Step 3: Complete analysis

--- a/backend/routes/inspect_backup.js
+++ b/backend/routes/inspect_backup.js
@@ -67,7 +67,8 @@ router.get('/active', async (req, res) => {
 });
 
 /**
- * GET /api/inspect/:imageName*/status
+ * GET /api/inspect/:imageName*
+ * /status
  * Get the status of an ongoing inspection (supports namespaced images)
  */
 router.get('/:imageName*/status',
@@ -321,12 +322,12 @@ router.post('/:imageName*',
         message: 'Starting dive analysis...'
       });
 
-      const analysis = await diveUtils.executeDive(decodedImageName, (diveUpdate) => {
-        progressCallback({
-          status: 'analyzing',
-          progress: Math.min(60 + (diveUpdate.progress || 0) * 0.35, 95), // 60-95%
-          message: diveUpdate.message || 'Analyzing image layers...'
-        });
+      const analysis = await diveUtils.executeDive(decodedImageName);
+
+      progressCallback({
+        status: 'analyzing',
+        progress: 95,
+        message: 'Processing analysis results...'
       });
 
       // Step 3: Complete analysis

--- a/backend/routes/inspect_new.js
+++ b/backend/routes/inspect_new.js
@@ -316,12 +316,12 @@ router.post('/:imageName*',
         message: 'Starting dive analysis...'
       });
 
-      const analysis = await diveUtils.executeDive(decodedImageName, (diveUpdate) => {
-        progressCallback({
-          status: 'analyzing',
-          progress: Math.min(60 + (diveUpdate.progress || 0) * 0.35, 95), // 60-95%
-          message: diveUpdate.message || 'Analyzing image layers...'
-        });
+      const analysis = await diveUtils.executeDive(decodedImageName);
+
+      progressCallback({
+        status: 'analyzing',
+        progress: 95,
+        message: 'Processing analysis results...'
       });
 
       // Step 3: Complete analysis

--- a/backend/utils/dive.js
+++ b/backend/utils/dive.js
@@ -22,10 +22,9 @@ class DiveUtils {
   /**
    * Execute dive analysis on a Docker image
    * @param {string} imageName - Name of the image to analyze
-   * @param {function} progressCallback - Optional callback for progress updates
    * @returns {Promise<Object>} Dive analysis results
    */
-  async executeDive(imageName, progressCallback = null) {
+  async executeDive(imageName) {
     try {
       console.log(`Starting dive analysis for image: ${imageName}`);
 
@@ -121,10 +120,9 @@ class DiveUtils {
   /**
    * Execute dive synchronously
    * @param {string} imageName - Name of the image to analyze
-   * @param {string} outputFile - Path to output file
    * @returns {Promise<Object>} Analysis results
    */
-  async executeDiveSync(imageName, outputFile) {
+  async executeDiveSync(imageName) {
     if (!dockerImageRegex.test(imageName)) {
       throw new Error(`Invalid image name: ${imageName}`);
     }
@@ -181,11 +179,10 @@ class DiveUtils {
   /**
    * Execute dive with real-time progress updates
    * @param {string} imageName - Name of the image to analyze
-   * @param {string} outputFile - Path to output file
    * @param {function} progressCallback - Callback for progress updates
    * @returns {Promise<Object>} Analysis results
    */
-  executeDiveWithProgress(imageName, outputFile, progressCallback) {
+  executeDiveWithProgress(imageName, progressCallback) {
     return new Promise((resolve, reject) => {
       if (!dockerImageRegex.test(imageName)) {
         return reject(new Error(`Invalid image name: ${imageName}`));


### PR DESCRIPTION
## Summary
- remove unused progress and output file params from dive utilities
- update inspect routes for simplified API

## Testing
- `npm run test:backend`
- `npm run lint:backend` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa61dc4388322b33f2c534f90e2d1